### PR TITLE
fix: missing change to go crashes the workflow

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -43,7 +43,7 @@ jobs:
         id: apidiff
         run: |
           cd ${{ inputs.project-path }}
-          git diff --name-only origin/main HEAD | grep '\.go$' > changes.txt
+          git diff --name-only origin/main HEAD | grep '\.go$' || true > changes.txt
           if [ -s changes.txt ]; then
             echo "Detected Go changes. Checking API diff..."
 


### PR DESCRIPTION
[See](https://github.com/coopnorge/the-playground-arunpoudel/actions/runs/6546671529/job/17777595144) for a failure run.

The problem arises when the PR contains no changes to `*.go` files.
line 46 of the workflow `grep '\.go$'` fails with exit code 1
Which cause the whole workflow to fail.
