### PR TITLE
fix: changes to go files not being detected

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -43,7 +43,7 @@ jobs:
         id: apidiff
         run: |
           cd ${{ inputs.project-path }}
-          git diff --name-only origin/main HEAD | grep '\.go$' || true > changes.txt
+          git diff --name-only origin/main HEAD | grep '\.go$' > changes.txt || true
           if [ -s changes.txt ]; then
             echo "Detected Go changes. Checking API diff..."
 


### PR DESCRIPTION
[See](https://github.com/coopnorge/the-playground-arunpoudel/actions/runs/6619154811/job/17979081303?pr=8)

Looks like changes to go files were logged to STDOUT instead of changes.txt
which was causing workflows to always tag the change as patch.
