### PR TITLE
fix: check apidiff against all folders, not just the root folder

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -47,10 +47,10 @@ jobs:
           if [ -s changes.txt ]; then
             echo "Detected Go changes. Checking API diff..."
 
-            apidiff -w new.txt .
+            apidiff -w new.txt ./...
 
             git checkout origin/main
-            apidiff -w old.txt .
+            apidiff -w old.txt ./...
 
             DIFFERENCE=$(apidiff old.txt new.txt)
             if [ "$DIFFERENCE" != "" ]; then


### PR DESCRIPTION
This fixes the issue where all the go-code is located in sub-directories.
https://github.com/coopnorge/go-services-interfaces/actions/runs/6747318326/job/18343189428?pr=30