### PR TITLE
fix: use -m flag for apidiff to signal that we are operating in a module

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -47,10 +47,10 @@ jobs:
           if [ -s changes.txt ]; then
             echo "Detected Go changes. Checking API diff..."
 
-            apidiff -w new.txt ./...
+            apidiff -m -w new.txt .
 
             git checkout origin/main
-            apidiff -w old.txt ./...
+            apidiff -m -w old.txt .
 
             DIFFERENCE=$(apidiff old.txt new.txt)
             if [ "$DIFFERENCE" != "" ]; then


### PR DESCRIPTION
Looks like apidiff was only operating in package level. Which meant
that only packages that were included by files in root directory
were enumurated when considering the apidiff.

Treating the folder as a module, enumurates all path and sub-path.
[See](https://github.com/coopnorge/github-workflow-release-drafter/issues/12)
on discussion related to this.

Fixes: #12
