### PR TITLE
Enable dependabot updates and pin versions using tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       - coop-ghcr
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v4.1.0
         with:
           go-version-file: '${{ inputs.project-path }}/go.mod'
       - name: Install API DIff
@@ -74,7 +74,7 @@ jobs:
             echo "No Go changes detected."
             echo "semver-type=patch" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v6.4.1
         if: github.event_name == 'pull_request'
         env:
           LABEL: '${{ steps.apidiff.outputs.semver-type }}'

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -24,7 +24,7 @@ jobs:
   update-release-draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772
+      - uses: release-drafter/release-drafter@v5.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The dependency pinning for essential packages is either too free or either too restricted. Pinning (almost) everything by tags and enabling dependabot updates should make this better.