### PR TITLE
fix: fixes release tagger crashing because it cannot find tag correctly

### DIFF
--- a/.github/workflows/release-tagger.yaml
+++ b/.github/workflows/release-tagger.yaml
@@ -25,7 +25,7 @@ jobs:
           NEW_TAG=$(echo "${{ github.event.release.tag_name }}" | cut -d'.' -f1)
 
           # Check if tag already exists and delete if it does
-          if git show-ref --tags $NEW_TAG; then
+          if [ $(git tag -l $NEW_TAG) ]; then
               git tag -d $NEW_TAG
               git push --delete origin $NEW_TAG
           fi

--- a/.github/workflows/release-tagger.yaml
+++ b/.github/workflows/release-tagger.yaml
@@ -25,5 +25,5 @@ jobs:
           NEW_TAG=$(echo "${{ github.event.release.tag_name }}" | cut -d'.' -f1)
 
           # Create new tag
-          git tag $NEW_TAG
+          git tag -f $NEW_TAG -m "Forcing tag to match release"
           git push origin -f --tags

--- a/.github/workflows/release-tagger.yaml
+++ b/.github/workflows/release-tagger.yaml
@@ -24,12 +24,6 @@ jobs:
           # Extract vX from vX.Y.Z
           NEW_TAG=$(echo "${{ github.event.release.tag_name }}" | cut -d'.' -f1)
 
-          # Check if tag already exists and delete if it does
-          if [ $(git tag -l $NEW_TAG) ]; then
-              git tag -d $NEW_TAG
-              git push --delete origin $NEW_TAG
-          fi
-
           # Create new tag
           git tag $NEW_TAG
-          git push origin refs/tags/$NEW_TAG
+          git push origin -f --tags

--- a/.github/workflows/release-tagger.yaml
+++ b/.github/workflows/release-tagger.yaml
@@ -26,4 +26,4 @@ jobs:
 
           # Create new tag
           git tag -f $NEW_TAG -m "Forcing tag to match release"
-          git push origin -f --tags
+          git push origin -f $NEW_TAG


### PR DESCRIPTION
[See](https://github.com/coopnorge/github-workflow-release-drafter/actions/runs/6927907177/attempts/1)
for failing run.

This run probably fails because, it cannot find v0 tag.
Force pushing the tag should mitigate this problem.

Fixes #29 
