### PR TITLE
feat: allow ignoring of major changes if path matches pattern

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -25,6 +25,16 @@ on:
         description: The path to go project
         required: false
         default: .
+      ignore-major-changes-for-pattern:
+        type: string
+        description: >-
+          A regular expression pattern to match against incompatible changes.
+          If incompatible changes are detected only on files matching this
+          pattern, the release drafter will not bump the major version.
+          Eg: (\S+)\/(v1beta1)\.(\S+), this will ignore incompatible changes
+          in v1beta1 in the path.
+        required: false
+        default: ''
     outputs:
       id:
         value: ${{ jobs.draft-release.outputs.id }}
@@ -86,8 +96,20 @@ jobs:
               echo "API diff detected. $DIFFERENCE"
 
               if echo "$DIFFERENCE" | grep -q -i "incompatible change"; then
-                echo "Incompatible API change detected."
-                echo "semver-type=major" >> $GITHUB_OUTPUT
+                if [ "${{ inputs.ignore-major-changes-for-pattern }}" != "" ]; then
+
+                  if apidiff -m -incompatible old.txt new.txt | grep -qvE "${{ inputs.ignore-major-changes-for-pattern }}"; then
+                    # If the change is not ignored by the pattern, bump major
+                    echo "Incompatible API change detected."
+                    echo "semver-type=major" >> $GITHUB_OUTPUT
+                  else
+                    echo "Incompatible API change detected, but ignored by pattern."
+                    echo "semver-type=minor" >> $GITHUB_OUTPUT
+                  fi
+                else
+                  echo "Incompatible API change detected."
+                  echo "semver-type=major" >> $GITHUB_OUTPUT
+                fi
               elif echo "$DIFFERENCE" | grep -q -i "compatible change"; then
                 echo "Compatible API change detected."
                 echo "semver-type=minor" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Context:

We have had issues in our internal projects where release-drafter-go
was being used to automatically tag go projects, where the
release-drafter tagged the PR as major changes because
it was trying to introduce breaking changes to a path, `*/v1beta1.*`

We have agreed on that specific project, that breaking changes are allowed
for v1beta1 beta however not allowed for v1 APIs.

We needed a mechanism in release-drafter-go that allowed us to ignore
major changes to path matching a pattern, and simply tag it as a minor
bump.
