### PR TITLE
feat: add namespace release-drafter-go to labels in PR

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -136,7 +136,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: [`${LABEL}`]
+              labels: [`release-drafter-go:${LABEL}`]
             })
   draft-release:
     name: Draft Release


### PR DESCRIPTION
Now that dependabot has been adding labels to our PRs,
`major`, `minor` etc, our release drafter started bugging out
because those PRs were considered part of the version bump
on projects where release-drafter are used.

The namespace from release-drafter is controlled from central repo
[.github](https://github.com/coopnorge/.github) by PR
https://github.com/coopnorge/.github/pull/6
