### PR TITLE
fix: pattern description

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -29,12 +29,14 @@ on:
         type: string
         description: >-
           A regular expression pattern to match against incompatible changes.
-          If incompatible changes are detected only on files matching this
-          pattern, the release drafter will not bump the major version.
-          Eg: (\S+)\/(v1beta1)\.(\S+), this will ignore incompatible changes
-          in v1beta1 in the path.
+          If incompatible changes are detected only api-diff's output 
+          matching this pattern, the release drafter will not bump the major version.
+          (\S+)\/(v1beta2)\.(\S+), this will ignore incompatible changes
+          in v1beta1 in the api-diff output, eg:
+          ./coopnorge/customerdirectory/v1beta2.(*CustomerContactInformation).GetEmailAddresses: removed
+          will be ignore by the above pattern as it matches the regex provided.
         required: false
-        default: ''
+        default: ""
     outputs:
       id:
         value: ${{ jobs.draft-release.outputs.id }}
@@ -75,7 +77,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version-file: '${{ inputs.project-path }}/go.mod'
+          go-version-file: "${{ inputs.project-path }}/go.mod"
       - name: Install API DIff
         run: go install golang.org/x/exp/cmd/apidiff@latest
       - name: Get PR diff
@@ -128,7 +130,7 @@ jobs:
       - uses: actions/github-script@v7.0.1
         if: github.event_name == 'pull_request'
         env:
-          LABEL: '${{ steps.apidiff.outputs.semver-type }}'
+          LABEL: "${{ steps.apidiff.outputs.semver-type }}"
         with:
           script: |
             const { LABEL } = process.env;
@@ -143,6 +145,6 @@ jobs:
     uses: >-
       coopnorge/github-workflow-release-drafter/.github/workflows/release-drafter.yaml@v0.5.0
     with:
-      config-name: '${{ inputs.config-name }}'
-      commitish: '${{ inputs.commitish }}'
+      config-name: "${{ inputs.config-name }}"
+      commitish: "${{ inputs.commitish }}"
       publish: ${{ inputs.publish }}

--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -34,7 +34,7 @@ on:
           (\S+)\/(v1beta2)\.(\S+), this will ignore incompatible changes
           in v1beta1 in the api-diff output, eg:
           ./coopnorge/customerdirectory/v1beta2.(*CustomerContactInformation).GetEmailAddresses: removed
-          will be ignore by the above pattern as it matches the regex provided.
+          will be ignored by the above pattern as it matches the regex provided.
         required: false
         default: ""
     outputs:

--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -29,12 +29,11 @@ on:
         type: string
         description: >-
           A regular expression pattern to match against incompatible changes.
-          If incompatible changes are detected only api-diff's output 
+          If incompatible changes are detected on api-diff's output 
           matching this pattern, the release drafter will not bump the major version.
-          (\S+)\/(v1beta2)\.(\S+), this will ignore incompatible changes
-          in v1beta1 in the api-diff output, eg:
-          ./coopnorge/customerdirectory/v1beta2.(*CustomerContactInformation).GetEmailAddresses: removed
-          will be ignored by the above pattern as it matches the regex provided.
+          Eg: (\S+)\/(v\d+beta\d+)\.(\S+), this will ignore incompatible changes
+          in the api-diff output, matching
+          ./coopnorge/<projectpath>/v1beta2.(<RPCNameORMessageName>).GetEmailAddresses: removed
         required: false
         default: ""
     outputs:


### PR DESCRIPTION
The pattern description was saying that it checks against files,
but that is not the case according to the implementation.

https://github.com/coopnorge/github-workflow-release-drafter/blob/edebea3066df304b5e3ffaf8e3d153847f48ffa2/.github/workflows/release-drafter-go.yaml#L99-L105

The implementation matches the pattern against `api-diff`'s output.
