### PR TITLE
Add functionality to configure access to internal and private repositories

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -81,10 +81,12 @@ jobs:
         with:
           go-version-file: "${{ inputs.project-path }}/go.mod"
       - name: Configure access to internal and private GitHub repos
-        env:
-          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
-        if: ${{ env.GITHUB_OAUTH_TOKEN != '' }}
-        run: git config --global url."https://${{ secrets.GITHUB_OAUTH_TOKEN }}:x-oauth-basic@github.com/coopnorge".insteadOf "https://github.com/coopnorge"
+        run: |
+          if [ -n "${{ secrets.GITHUB_OAUTH_TOKEN }}" ]; then
+            git config --global url."https://${{ secrets.GITHUB_OAUTH_TOKEN }}:x-oauth-basic@github.com/coopnorge".insteadOf "https://github.com/coopnorge";
+          else
+            echo "GITHUB_OAUTH_TOKEN is not set. Skipping Git configuration.";
+          fi
       - name: Install API DIff
         run: go install golang.org/x/exp/cmd/apidiff@latest
       - name: Get PR diff

--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -1,5 +1,8 @@
 on:
   workflow_call:
+    secrets:
+      GITHUB_OAUTH_TOKEN:
+        required: false
     inputs:
       config-name:
         type: string
@@ -77,6 +80,11 @@ jobs:
       - uses: actions/setup-go@v5.0.2
         with:
           go-version-file: "${{ inputs.project-path }}/go.mod"
+      - name: Configure access to internal and private GitHub repos
+        env:
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+        if: ${{ env.GITHUB_OAUTH_TOKEN != '' }}
+        run: git config --global url."https://${{ secrets.GITHUB_OAUTH_TOKEN }}:x-oauth-basic@github.com/coopnorge".insteadOf "https://github.com/coopnorge"
       - name: Install API DIff
         run: go install golang.org/x/exp/cmd/apidiff@latest
       - name: Get PR diff

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ specify the `project-path`.
 **NOTE:** GITHUB_OAUTH_TOKEN should be supplied if you reference other 
 internal/private repositories
 
+
 ```yaml
 pull-requests: write
 contents: write

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,8 @@ specify the `project-path`.
 
 **NOTE:** Make sure to request permissions
 
-**NOTE:** GITHUB_OAUTH_TOKEN should be supplied if you reference other internal/private repositories
+**NOTE:** GITHUB_OAUTH_TOKEN should be supplied if you reference other 
+internal/private repositories
 
 ```yaml
 pull-requests: write

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,6 @@ specify the `project-path`.
 **NOTE:** GITHUB_OAUTH_TOKEN should be supplied if you reference other 
 internal/private repositories
 
-
 ```yaml
 pull-requests: write
 contents: write

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,12 +57,16 @@ jobs:
     uses: coopnorge/github-workflow-release-drafter/.github/workflows/release-drafter-go.yaml@v0.1.0
     with:
       project-path: "./go-playground"
+    secrets:
+      GITHUB_OAUTH_TOKEN: ${{ secrets.OUR_GITHUB_TOKEN }}
 ```
 
 **NOTE:** As we generally have projects inside subdirectories, we need to
 specify the `project-path`.
 
 **NOTE:** Make sure to request permissions
+
+**NOTE:** GITHUB_OAUTH_TOKEN should be supplied if you reference other internal/private repositories
 
 ```yaml
 pull-requests: write

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ specify the `project-path`.
 
 **NOTE:** Make sure to request permissions
 
-**NOTE:** GITHUB_OAUTH_TOKEN should be supplied if you reference other 
+**NOTE:** GITHUB_OAUTH_TOKEN should be supplied if you reference other
 internal/private repositories
 
 ```yaml


### PR DESCRIPTION
The goal of this PR is to simplify setting up the release-drafter for go libraries that reference other internal/private libraries, by configuring the OAUTH if the secret is passed to it.