### PR TITLE
feat: Diff changes since last tag (release)

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -86,7 +86,8 @@ jobs:
         id: apidiff
         run: |
           cd ${{ inputs.project-path }}
-          git diff --name-only origin/main HEAD | grep '\.go$' > changes.txt || true
+          TAG=$(git describe --tags --abbrev=0)
+          git diff --name-only ${TAG} HEAD | grep '\.go$' > changes.txt || true
           if [ -s changes.txt ]; then
             echo "Detected Go changes. Checking API diff..."
 


### PR DESCRIPTION
This change addresses the false positive detection of breaking changes
when PRs break a change that is not yet part of a release. This should
remove some accidental major version bumps and allow use to
revert/change things before release, but after a change is merged to
main. A similar breaking policy has been put in place in
[github.com/services-interfaces].

[github.com/services-interfaces]: https://github.com/coopnorge/services-interfaces/pull/660
