### PR TITLE
chore: add caching for setup-go

### DIFF
--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -73,6 +73,7 @@ jobs:
       - uses: actions/setup-go@v5.5.0
         with:
           go-version-file: "${{ inputs.project-path }}/go.mod"
+          cache-dependency-path: "${{ inputs.project-path }}/go.sum"
       - name: Configure access to internal and private GitHub repos
         run: |
           if [ -n "${{ secrets.REVIEWBOT_GITHUB_TOKEN }}" ]; then


### PR DESCRIPTION
`actions/setup-go` looks for `go.sum` in project root by default

> Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/cloud-platform-apis/cloud-platform-apis. Supported file pattern: go.sum

ref: https://github.com/coopnorge/cloud-platform-apis/actions/runs/15211395050/job/42786186358?pr=243