### PR TITLE
chore!: update to 7.x, restore autolabeler and fix example config file

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,40 +4,50 @@ change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'
 categories:
   - title: "🔥 BREAKING CHANGES"
-    labels:
-      - "breaking-change"
+    semver-increment: "major"
+    when:
+      label: "breaking-change"
   - title: "🚀 Features"
-    labels:
-      - "enhancement"
+    semver-increment: "minor"
+    when:
+      label: "enhancement"
   - title: "🐛 Bug Fixes"
-    labels:
-      - "bug-fix"
+    semver-increment: "patch"
+    when:
+      label: "bug-fix"
   - title: "👷 Chores"
-    labels:
-      - "chore"
+    semver-increment: "patch"
+    when:
+      label: "chore"
   - title: "⚡️ Deprecations"
-    labels:
-      - "deprecation"
+    semver-increment: "patch"
+    when:
+      label: "deprecation"
   - title: "⬆️ Dependencies Upgraded"
-    labels:
-      - "dependency"
-exclude-labels:
-  - "skip-changelog"
+    semver-increment: "patch"
+    when:
+      label: "dependency"
+  - type: "pre-exclude"
+    when:
+      label: "skip-changelog"
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      label: "major"
+  - type: "version-resolver"
+    semver-increment: "minor"
+    when:
+      label: "minor"
+  - type: "version-resolver"
+    semver-increment: "patch"
+    when:
+      label: "patch"
+  - type: "version-resolver"
+    semver-increment: "patch"
 replacers:
   # https://github.com/release-drafter/release-drafter/issues/569#issuecomment-645938155
   - search: '(?:and )?@dependabot(?:\[bot\])?,?'
     replace: ""
-version-resolver:
-  major:
-    labels:
-      - "major"
-  minor:
-    labels:
-      - "minor"
-  patch:
-    labels:
-      - "patch"
-  default: patch
 exclude-contributors:
   - "dependabot"
 autolabeler:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
       contents: write
       issues: write
-    uses: coopnorge/github-workflow-release-drafter/.github/workflows/release-drafter.yaml@v0.10.3
+    uses: ./.github/workflows/release-drafter.yaml
   build:
     if: failure() || cancelled()
     needs: ['release-draft']

--- a/.github/workflows/release-drafter-go.yaml
+++ b/.github/workflows/release-drafter-go.yaml
@@ -152,7 +152,7 @@ jobs:
   draft-release:
     name: Draft Release
     uses: >-
-      coopnorge/github-workflow-release-drafter/.github/workflows/release-drafter.yaml@v0.10.1
+      ./.github/workflows/release-drafter.yaml
     with:
       config-name: "${{ inputs.config-name }}"
       commitish: "${{ inputs.commitish }}"

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -64,9 +64,16 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         id: update-release-draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          commitish: '${{ inputs.commitish }}'
-          config-name: '${{ inputs.config-name }}'
-          publish: '${{ inputs.publish }}'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commitish: "${{ inputs.commitish }}"
+          config-name: "${{ inputs.config-name }}"
+          publish: "${{ inputs.publish }}"
+  autolabel:
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-slim
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-name: "${{ inputs.config-name }}"

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -62,7 +62,7 @@ jobs:
       html_url: ${{ steps.update-release-draft.outputs.html_url }}
       upload_url: ${{ steps.update-release-draft.outputs.upload_url }}
     steps:
-      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         id: update-release-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
v7.x removes autolabeler by default and it needs to be called separately. Also, there are deprecations in the config file which have been fixed, which is handled by this codemod: https://github.com/coopnorge/codemod/pull/354

resolves: https://github.com/coopnorge/github-workflow-release-drafter/issues/121